### PR TITLE
Add ROS 2 Source Build Pipeline

### DIFF
--- a/.github/workflows/source-build.yaml
+++ b/.github/workflows/source-build.yaml
@@ -1,0 +1,16 @@
+name: Source Build
+# Build all ROS 2 packages in the repository and submodules
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *" # Runs daily to check for depency issues or flaking tests
+jobs:
+  source-build:
+    uses: vortexntnu/vortex-ci/.github/workflows/reusable-source-build.yaml@main
+    with:
+      ros_distro: 'humble'
+      os_name: 'ubuntu-22.04'
+      ref: ${{ github.ref_name }}
+      vcs_repo_file_url: ""
+      skip_tests: true
+      gcc_version: '13'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "submodules/vortex-aruco-detection"]
 	path = submodules/vortex-aruco-detection
-	url = git@github.com:vortexntnu/vortex-aruco-detection.git
+	url = https://github.com/vortexntnu/vortex-aruco-detection.git
 [submodule "submodules/vortex-image-filtering"]
 	path = submodules/vortex-image-filtering
-	url = git@github.com:vortexntnu/vortex-image-filtering.git
+	url = https://github.com/vortexntnu/vortex-image-filtering.git
 [submodule "submodules/vortex-blackfly-driver"]
 	path = submodules/vortex-blackfly-driver
-	url = git@github.com:vortexntnu/vortex-blackfly-driver.git
+	url = https://github.com/vortexntnu/vortex-blackfly-driver.git
 [submodule "submodules/vortex-vkf"]
 	path = submodules/vortex-vkf
-	url = git@github.com:vortexntnu/vortex-vkf.git
+	url = https://github.com/vortexntnu/vortex-vkf.git


### PR DESCRIPTION
This PR introduces a GitHub Actions pipeline to build all ROS 2 packages in the repository and submodules. The pipeline is scheduled to run daily. The purpose is to ensure the packages build correctly, to check for any dependency issues. In the future it can also be used to detect flaking tests, but for now it skips tests.

Also updated the .gitmodules to use https instead of ssh to ensure compatibility with the pipeline.